### PR TITLE
Fixed issues with windows encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.bsc.util</groupId>
   <artifactId>minitemplator-repackaged</artifactId>
   <name>MiniTemplator - ${project.version}</name>
-  <version>1.4</version>
+  <version>1.5-SNAPSHOT</version>
   <description>MiniTemplator is a compact template engine for HTML files.</description>
   <url>http://www.source-code.biz/MiniTemplator</url>
 
@@ -144,6 +144,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
 <profiles>

--- a/src/main/java/biz/source_code/miniTemplator/MiniTemplator.java
+++ b/src/main/java/biz/source_code/miniTemplator/MiniTemplator.java
@@ -677,7 +677,7 @@ public class MiniTemplator {
 
         generateOutput(out);
         out.flush();
-        return baos.toString();
+        return baos.toString(charset.name());
     }
   }
 


### PR DESCRIPTION
I had an issue on a Windows machine that uses Windows-1252 as default encoding for the JVM. When using an UTF-8 encoded template and setting the encoding of MiniTemplator to UTF-8, it would generate a document with broken diacritics. ParseTest.encodingTest also failed on this machine. I fixed the issue by adding the encoding as a parameter to the toString method in generateOutput().

After the fix, ParseTest.encodingTest would still fail even when the MiniTemplator output was now correct. This was caused by the "expected_utf8" string being compiled into the test class file with the wrong encoding. It would then compare the correct UTF-8 output or MiniTemplator to the broken expected value, causing it to fail. Setting the project.build.sourceEncoding to UTF-8 fixed that problem.

I tried writing a test for this specific issue, but could not find a way to execute it with the default encoding set to Windows-1252 on a machine that is configured for UTF-8. I did run the existing tests both with file.encoding set to UTF8 and to Windows-1252 and in both situations, they pass.